### PR TITLE
Fix strategy update merge logic

### DIFF
--- a/src/algorithms/sheet/MultiObjectiveOptimizer.ts
+++ b/src/algorithms/sheet/MultiObjectiveOptimizer.ts
@@ -204,7 +204,21 @@ export class MultiObjectiveOptimizer {
 
   // Configurar estratégias de otimização
   setOptimizationStrategy(strategy: Partial<AdvancedOptimizationConfig>): void {
-    this.config = { ...this.config, ...strategy };
+    if (strategy.strategies) {
+      const updatedStrategies = { ...this.config.strategies };
+
+      for (const key of Object.keys(strategy.strategies) as Array<keyof AdvancedOptimizationConfig['strategies']>) {
+        updatedStrategies[key] = {
+          ...updatedStrategies[key],
+          ...strategy.strategies[key]
+        };
+      }
+
+      this.config = { ...this.config, ...strategy, strategies: updatedStrategies };
+    } else {
+      this.config = { ...this.config, ...strategy };
+    }
+
     console.log('Estratégia de otimização atualizada:', this.config);
   }
 


### PR DESCRIPTION
## Summary
- preserve existing strategies when updating optimization configuration

## Testing
- `npx tsc --noEmit -p tsconfig.node.json` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_b_68629c495678832d894dee49ef5fa183