### PR TITLE
Add basic optimizer test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/tests/bottomLeftFill.test.ts
+++ b/tests/bottomLeftFill.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { BottomLeftFillOptimizer } from '../src/algorithms/sheet/BottomLeftFill'
+import type { SheetCutPiece } from '../src/types/sheet'
+
+describe('BottomLeftFillOptimizer', () => {
+  it('places two small rectangles on one sheet', () => {
+    const optimizer = new BottomLeftFillOptimizer(500, 500)
+    const pieces: SheetCutPiece[] = [
+      { id: '1', width: 100, height: 100, quantity: 1, tag: 'P1', allowRotation: false },
+      { id: '2', width: 100, height: 100, quantity: 1, tag: 'P2', allowRotation: false }
+    ]
+
+    const result = optimizer.optimize(pieces)
+
+    expect(result.totalSheets).toBe(1)
+    expect(result.sheets).toHaveLength(1)
+    expect(result.sheets[0].pieces).toHaveLength(2)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- add vitest configuration and simple test for BottomLeftFillOptimizer
- expose `npm test` script for running tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863bbde3ab0832da54a82eacaeea474