### PR TITLE
Add admin user management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Login from "./pages/Login";
 import NotFound from "./pages/NotFound";
+import AdminUsuarios from "./pages/AdminUsuarios";
 
 const queryClient = new QueryClient();
 
@@ -18,6 +19,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/login" element={<Login />} />
+          <Route path="/admin" element={<AdminUsuarios />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,10 +18,13 @@ export const Header = () => {
           </div>
           
           <div className="hidden md:flex items-center space-x-4">
-            <div className="text-right">
+            <div className="text-right mr-4">
               <p className="text-sm text-blue-100">Bem-vindo ao sistema</p>
               <p className="text-xs text-blue-200">Versão 2.0</p>
             </div>
+            <a href="/admin" className="text-sm underline hover:text-blue-200">
+              Admin
+            </a>
           </div>
           
           <Button variant="ghost" size="sm" className="md:hidden text-white">

--- a/src/pages/AdminUsuarios.tsx
+++ b/src/pages/AdminUsuarios.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { usuarioService } from '@/services';
+import type { Usuario } from '@/services';
+
+const AdminUsuarios = () => {
+  const [usuarios, setUsuarios] = useState<Usuario[]>([]);
+  const [novo, setNovo] = useState({ nome: '', email: '', role: 'user' });
+  const [editando, setEditando] = useState<Usuario | null>(null);
+
+  const carregar = async () => {
+    const { data } = await usuarioService.getAll();
+    if (data) setUsuarios(data);
+  };
+
+  useEffect(() => {
+    carregar();
+  }, []);
+
+  const salvarNovo = async () => {
+    await usuarioService.create({ data: novo });
+    setNovo({ nome: '', email: '', role: 'user' });
+    carregar();
+  };
+
+  const salvarEdicao = async () => {
+    if (!editando) return;
+    await usuarioService.update({ id: editando.id, data: editando });
+    setEditando(null);
+    carregar();
+  };
+
+  const remover = async (id: string) => {
+    await usuarioService.delete({ id });
+    carregar();
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 p-6">
+      <div className="container mx-auto space-y-6">
+        <Card className="bg-white/90 backdrop-blur-sm shadow-lg border-0">
+          <CardHeader className="bg-gradient-to-r from-blue-600 to-indigo-700 text-white rounded-t-lg">
+            <CardTitle>Cadastro de Usuários</CardTitle>
+          </CardHeader>
+          <CardContent className="p-6 space-y-4">
+            <div className="grid grid-cols-3 gap-4">
+              <Input
+                placeholder="Nome"
+                value={novo.nome}
+                onChange={(e) => setNovo({ ...novo, nome: e.target.value })}
+              />
+              <Input
+                placeholder="Email"
+                value={novo.email}
+                onChange={(e) => setNovo({ ...novo, email: e.target.value })}
+              />
+              <Input
+                placeholder="Role"
+                value={novo.role}
+                onChange={(e) => setNovo({ ...novo, role: e.target.value })}
+              />
+            </div>
+            <Button onClick={salvarNovo} disabled={!novo.nome || !novo.email}>
+              Criar Usuário
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-white/90 backdrop-blur-sm shadow-lg border-0">
+          <CardHeader className="bg-gradient-to-r from-emerald-600 to-green-700 text-white rounded-t-lg">
+            <CardTitle>Usuários Cadastrados</CardTitle>
+          </CardHeader>
+          <CardContent className="p-6 overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Nome</th>
+                  <th className="p-2">Email</th>
+                  <th className="p-2">Role</th>
+                  <th className="p-2">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {usuarios.map((u) => (
+                  <tr key={u.id} className="border-t">
+                    <td className="p-2">{u.nome}</td>
+                    <td className="p-2">{u.email}</td>
+                    <td className="p-2">{u.role}</td>
+                    <td className="p-2 space-x-2">
+                      <Button variant="secondary" size="sm" onClick={() => setEditando(u)}>
+                        Editar
+                      </Button>
+                      <Button variant="destructive" size="sm" onClick={() => remover(u.id)}>
+                        Excluir
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+
+        {editando && (
+          <Card className="bg-white/90 backdrop-blur-sm shadow-lg border-0">
+            <CardHeader className="bg-gradient-to-r from-yellow-600 to-amber-700 text-white rounded-t-lg">
+              <CardTitle>Editar Usuário</CardTitle>
+            </CardHeader>
+            <CardContent className="p-6 space-y-4">
+              <div className="grid grid-cols-3 gap-4">
+                <Input
+                  placeholder="Nome"
+                  value={editando.nome}
+                  onChange={(e) => setEditando({ ...editando, nome: e.target.value })}
+                />
+                <Input
+                  placeholder="Email"
+                  value={editando.email}
+                  onChange={(e) => setEditando({ ...editando, email: e.target.value })}
+                />
+                <Input
+                  placeholder="Role"
+                  value={editando.role}
+                  onChange={(e) => setEditando({ ...editando, role: e.target.value })}
+                />
+              </div>
+              <div className="space-x-2">
+                <Button onClick={salvarEdicao}>Salvar</Button>
+                <Button variant="secondary" onClick={() => setEditando(null)}>
+                  Cancelar
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdminUsuarios;

--- a/src/services/entities/UsuarioService.ts
+++ b/src/services/entities/UsuarioService.ts
@@ -1,0 +1,10 @@
+import { BaseService } from '../base/BaseService';
+import type { Usuario } from '../interfaces';
+
+export class UsuarioService extends BaseService<Usuario> {
+  constructor() {
+    super('usuarios');
+  }
+}
+
+export const usuarioService = new UsuarioService();

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -24,3 +24,4 @@ export { inspetorService } from './entities/InspetorService';
 export { projetoService } from './entities/ProjetoService';
 export { estoqueSobrasService } from './entities/EstoqueSobrasService';
 export { historicoOtimizacaoService } from './entities/HistoricoOtimizacaoService';
+export { usuarioService } from './entities/UsuarioService';

--- a/src/services/interfaces/index.ts
+++ b/src/services/interfaces/index.ts
@@ -64,3 +64,9 @@ export interface HistoricoOtimizacao extends BaseEntity {
   resultados: any;
   bar_length: number;
 }
+
+export interface Usuario extends BaseEntity {
+  nome: string;
+  email: string;
+  role: string;
+}

--- a/supabase/migrations/20250622120000-add-usuarios-table.sql
+++ b/supabase/migrations/20250622120000-add-usuarios-table.sql
@@ -1,0 +1,12 @@
+-- Create table for system users
+CREATE TABLE public.usuarios (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email text NOT NULL UNIQUE,
+  nome text NOT NULL,
+  role text NOT NULL DEFAULT 'user',
+  created_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+-- Enable RLS and allow all for now
+ALTER TABLE public.usuarios ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow all on usuarios" ON public.usuarios FOR ALL USING (true) WITH CHECK (true);


### PR DESCRIPTION
## Summary
- add user management page and service
- link admin page in header and router
- create migration for `usuarios` table

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863d95dbedc832db44ccf3fc3a47af1