### PR TITLE
Add logout and back navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,17 @@
 
-import { Scissors, Menu } from 'lucide-react';
+import { Scissors, Menu, LogOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
 
 export const Header = () => {
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    navigate('/login');
+  };
+
   return (
     <header className="bg-gradient-to-r from-blue-600 to-indigo-700 text-white shadow-lg">
       <div className="container mx-auto px-4 py-6">
@@ -25,8 +34,15 @@ export const Header = () => {
             <a href="/admin" className="text-sm underline hover:text-blue-200">
               Admin
             </a>
+            <Button variant="secondary" size="sm" onClick={handleLogout}>
+              <LogOut className="w-4 h-4" />
+              Sair
+            </Button>
           </div>
-          
+
+          <Button variant="ghost" size="sm" onClick={handleLogout} className="md:hidden text-white">
+            <LogOut className="w-6 h-6" />
+          </Button>
           <Button variant="ghost" size="sm" className="md:hidden text-white">
             <Menu className="w-6 h-6" />
           </Button>

--- a/src/pages/AdminUsuarios.tsx
+++ b/src/pages/AdminUsuarios.tsx
@@ -13,12 +13,14 @@ import {
 import { supabase } from '@/integrations/supabase/client';
 import { usuarioService } from '@/services';
 import type { Usuario } from '@/services';
+import { useNavigate } from 'react-router-dom';
 
 const AdminUsuarios = () => {
   useAuthGuard('administrador')
   const [usuarios, setUsuarios] = useState<Usuario[]>([]);
   const [novo, setNovo] = useState({ nome: '', email: '', password: '', role: 'usuario' });
   const [editando, setEditando] = useState<Usuario | null>(null);
+  const navigate = useNavigate();
 
   const carregar = async () => {
     const { data } = await usuarioService.getAll();
@@ -69,6 +71,9 @@ const AdminUsuarios = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 p-6">
       <div className="container mx-auto space-y-6">
+        <Button variant="secondary" className="mb-4" onClick={() => navigate(-1)}>
+          Voltar
+        </Button>
         <Card className="bg-white/90 backdrop-blur-sm shadow-lg border-0">
           <CardHeader className="bg-gradient-to-r from-blue-600 to-indigo-700 text-white rounded-t-lg">
             <CardTitle>Cadastro de Usuários</CardTitle>


### PR DESCRIPTION
## Summary
- add logout button in header
- show mobile logout option
- add back navigation to user admin page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686688941004832db0222a9f2347cb55