### PR TITLE
Add admin tab and update header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,17 +27,16 @@ export const Header = () => {
           </div>
           
           <div className="hidden md:flex items-center space-x-4">
-            <div className="text-right mr-4">
-              <p className="text-sm text-blue-100">Bem-vindo ao sistema</p>
-              <p className="text-xs text-blue-200">Versão 2.0</p>
+            <div className="flex items-center mr-4 space-x-4">
+              <div className="text-right">
+                <p className="text-sm text-blue-100">Bem-vindo ao sistema</p>
+                <p className="text-xs text-blue-200">Versão 2.0</p>
+              </div>
+              <Button variant="secondary" size="sm" onClick={handleLogout}>
+                <LogOut className="w-4 h-4" />
+                Sair
+              </Button>
             </div>
-            <a href="/admin" className="text-sm underline hover:text-blue-200">
-              Admin
-            </a>
-            <Button variant="secondary" size="sm" onClick={handleLogout}>
-              <LogOut className="w-4 h-4" />
-              Sair
-            </Button>
           </div>
 
           <Button variant="ghost" size="sm" onClick={handleLogout} className="md:hidden text-white">


### PR DESCRIPTION
## Summary
- integrate AdminUsuarios as new `Administrador` tab
- fetch user role to conditionally display admin tab
- remove Admin link from header and align logout button next to the welcome message

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866921995c0832d9c6ddc0e6307785c